### PR TITLE
Rename MixMode to MixModeEnum

### DIFF
--- a/src/Main.hx
+++ b/src/Main.hx
@@ -20,7 +20,7 @@ import godot.AnimationNodeBlendSpace2D;
 import godot.AnimationNodeBlendSpace2D.AnimationNodeBlendSpace2D_BlendModeEnum;
 import godot.AnimationNodeBlendTree;
 import godot.AnimationNodeOneShot;
-import godot.AnimationNodeOneShot.AnimationNodeOneShot_MixMode;
+import godot.AnimationNodeOneShot.AnimationNodeOneShot_MixModeEnum;
 import godot.AnimationNodeOutput;
 import godot.AnimationNodeStateMachine;
 import godot.AnimationNodeStateMachinePlayback;


### PR DESCRIPTION
To generate the externs for the latest source code on Godot's 3.4 branch, I had to change one import because it looks like a type name changed.