### PR TITLE
Fix reflection2

### DIFF
--- a/src/Generate.macro.hx
+++ b/src/Generate.macro.hx
@@ -899,6 +899,10 @@ class Generate {
 								readOnly = true;
 							}
 
+							if (readOnly) {
+								metas.push("@:readOnly");
+							}
+
 							final name = static_ ? uppername(field.name) : safename(field.name.substr(0, 1).toLowerCase() + field.name.substr(1));
 							final kind = field.kind.match(FVar(_, _)) || field.kind.match(FProp("default", "never", _, _)) ? "F" : "P";
 							final doc = getDoc('$kind:Godot.${i.name.replace("_", ".")}.${field.name}', true);

--- a/src/Main.hx
+++ b/src/Main.hx
@@ -20,7 +20,7 @@ import godot.AnimationNodeBlendSpace2D;
 import godot.AnimationNodeBlendSpace2D.AnimationNodeBlendSpace2D_BlendModeEnum;
 import godot.AnimationNodeBlendTree;
 import godot.AnimationNodeOneShot;
-import godot.AnimationNodeOneShot.AnimationNodeOneShot_MixMode;
+import godot.AnimationNodeOneShot.AnimationNodeOneShot_MixModeEnum;
 import godot.AnimationNodeOutput;
 import godot.AnimationNodeStateMachine;
 import godot.AnimationNodeStateMachinePlayback;


### PR DESCRIPTION
Couldn't make this fix work locally without the fix in my other PR.

What it does is add @:readOnly meta on properties that can't be written, so that if `Reflect` is imported, it doesn't generate code that tries to set them.